### PR TITLE
Fix and a feature

### DIFF
--- a/FastSM/objects/oTest/Create_0.gml
+++ b/FastSM/objects/oTest/Create_0.gml
@@ -43,11 +43,11 @@ fsm.add( State.Foo, {
     }
 });
 
-fsm.transition_add( Trigger.A, {
+fsm.trigger_add( Trigger.A, {
     name : "Trigger A",
     include: all,
-    forbid: State.Bar,
-    transition : function(_source) {
+    forbid:  State.Bar,
+    trigger: function(_source) {
         switch _source {
             case State.Foo:
                 return State.Bar;
@@ -61,7 +61,8 @@ fsm.transition_add( Trigger.A, {
     }
 });
 
-fsm.build().start( State.Foo );
+fsm.build()
+fsm.start( State.Foo );
 fsm.trigger( Trigger.A );
 fsm.trigger( Trigger.A );
 fsm.trigger( Trigger.A );

--- a/FastSM/scripts/FastSM/FastSM.gml
+++ b/FastSM/scripts/FastSM/FastSM.gml
@@ -308,14 +308,14 @@ function FastSM(_size, _trigger_count) constructor {
             return;
         }
         if ((1<<__state_active) & _trigger[$ "__allow_mask"]) {
-            _result = _trigger[$ "trigger"]( __states[__state_active] );
+            _result = _trigger[$ "trigger"](__state_active, __states[__state_active] );
         } else {
             if ((1<<__state_active) & _trigger[$ "__forbid_mask"] || 
                 _trigger[$ "__exclude_mask"] & __states[__state_active][$ "__mask"]) {
                 return;
             }
             if (_trigger[$ "__include_mask"] & __states[__state_active][$ "__mask"]) {
-                _result = _trigger[$ "trigger"]( __states[__state_active] );
+                _result = _trigger[$ "trigger"](__state_active, __states[__state_active] );
             }
         }
         if (!_result) {

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ fsm.add( State.Foo, {
     }
 });
 
-fsm.transition_add( Trigger.A, {
+fsm.trigger_add( Trigger.A, {
     name : "Trigger A",
     include: all,
     forbid: State.Bar,
-    transition : function(_source) {
+    trigger : function(_source) {
         switch _source {
             case State.Foo:
                 return State.Bar;


### PR DESCRIPTION
In this commit I add a method to obtain the previous state
fsm_get_previous_state, previous

as well as arguments for enter and leave these are:

enter (this, previous)
where this is the current state and previous is the previous state, in some previous will be undefined.

leave(this, next)
where this is the current state and next is the next state.

solving #1
I fixed a small problem with the readme where it still kept elements from when the triggers were transitions.
fix some other bugs with triggers.

and added a new macro to indicate the current version, and fixed some tabs.